### PR TITLE
fix: broken anchor links

### DIFF
--- a/src/loading.ts
+++ b/src/loading.ts
@@ -116,7 +116,7 @@ function textOf(node: commonmark.Node) {
 
 function anchorFromTitle(title: string) {
   // Based on GitHub conventions
-  return '#' + title.replace(/[^a-zA-Z0-9]+/g, '-').toLowerCase().replace(/^-|-$/g, '');
+  return '#' + title.split(' ').join('-').replace(/[^a-zA-Z0-9-]+/g, '').toLowerCase();
 }
 
 async function fileExists(filename: string) {


### PR DESCRIPTION
Titles like "A & B" should have anchor link `a--b` but we previously were generating `a-b`